### PR TITLE
Nginx SM: Remove arch hardcode and kubeopenapi-jsonschema

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,23 +15,15 @@ COPY internal/ internal/
 COPY nginx/ nginx/
 COPY build/ build/
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s -X main.version=$VERSION -X main.gitsha=$GIT_COMMITSHA" -a -o meshery-nginx-sm main.go
-
-FROM alpine:3.15 as jsonschema-util
-RUN apk add --no-cache curl
-WORKDIR /
-RUN curl -LO https://github.com/layer5io/kubeopenapi-jsonschema/releases/download/v0.1.3/kubeopenapi-jsonschema
-RUN chmod +x /kubeopenapi-jsonschema
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s -X main.version=$VERSION -X main.gitsha=$GIT_COMMITSHA" -a -o meshery-nginx-sm main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/nodejs:14
 ENV DISTRO="debian"
-ENV GOARCH="amd64"
 ENV SERVICE_ADDR="meshery-nginx-sm"
 ENV MESHERY_SERVER="http://meshery:9081"
 COPY templates/ ./templates
 WORKDIR /
 COPY --from=builder /build/meshery-nginx-sm .
-COPY --from=jsonschema-util /kubeopenapi-jsonschema /root/.meshery/bin/kubeopenapi-jsonschema
 ENTRYPOINT ["/meshery-nginx-sm"]


### PR DESCRIPTION
**Description**
Removes hardcoding to amd64 arch.
Removes deprecated kubeopenapi-jsonschema

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
